### PR TITLE
Remove real device session key from docs and code

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -40,10 +40,10 @@ Frame sync word: `0xFFF348C4`. No DRM, no encryption, no proprietary codec.
 ### Session Authentication
 
 ```
->> APP&SK&xJiEbRKnKrhCqvoZ
+>> APP&SK&<16-char-session-key>
 << MCU&SK&OK
 ```
-Session key authenticates the connection. First 8 chars (`xJiEbRKn`) are reused as the WiFi AP password.
+The 16-character session key authenticates the connection. Capture yours by sniffing the vendor app's `APP&SK&` write with PacketLogger (or `pocket-libre sniff`). The first 8 characters are reused as the device's WiFi AP password — treat the key as a secret.
 
 ### Device Info
 
@@ -102,7 +102,7 @@ Complete sequence observed from official app:
 
 # 2. Get WiFi AP credentials
 >> APP&WIFI
-<< MCU&WIFI&PKT01_GREY_XXXXXXXX&xJiEbRKn   # SSID & password
+<< MCU&WIFI&PKT01_GREY_XXXXXXXX&XXXXXXXX   # SSID & password (first 8 chars of session key)
 
 # 3. Turn on WiFi AP
 >> APP&WIFIO

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -43,7 +43,7 @@ Frame sync word: `0xFFF348C4`. No DRM, no encryption, no proprietary codec.
 >> APP&SK&<16-char-session-key>
 << MCU&SK&OK
 ```
-The 16-character session key authenticates the connection. Capture yours by sniffing the vendor app's `APP&SK&` write with PacketLogger (or `pocket-libre sniff`). The first 8 characters are reused as the device's WiFi AP password — treat the key as a secret.
+The 16-character session key authenticates the connection. Capture yours from an HCI capture of the vendor app's `APP&SK&` write (e.g. PacketLogger on macOS/iOS, or Android's Bluetooth HCI snoop log) — `pocket-libre sniff` cannot see it, since it only observes notifications on its own connection. The first 8 characters are reused as the device's WiFi AP password — treat the key as a secret.
 
 ### Device Info
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pocket-libre setup
 
 The setup wizard walks you through:
 - Finding your Pocket device (BLE scan)
+- Entering your session key (capture it from the vendor app's `APP&SK&` write — see [PROTOCOL.md](PROTOCOL.md))
 - Entering your API keys (Anthropic for summaries, HuggingFace for speaker ID)
 - Choosing your output directory and preferences
 
@@ -83,7 +84,7 @@ All settings are stored in `~/.pocket-libre/config.toml`:
 ```toml
 [device]
 address = "YOUR-DEVICE-ADDRESS"
-session_key = "xJiEbRKnKrhCqvoZ"
+session_key = "YOUR-SESSION-KEY"
 
 [api]
 anthropic_key = "sk-ant-..."

--- a/src/pocket_libre/cli.py
+++ b/src/pocket_libre/cli.py
@@ -47,6 +47,18 @@ def _require_session_key(session_key: str | None, config: dict) -> str:
     return sk
 
 
+def _prompt_secret(label: str, existing: str) -> str | None:
+    """Prompt for a secret, showing a masked default when one exists.
+
+    Returns the stripped new value, or None to keep the existing one.
+    """
+    masked = f"...{existing[-4:]}" if len(existing) > 4 else ""
+    value = click.prompt(label, default=masked or "", show_default=bool(masked))
+    if value and not value.startswith("..."):
+        return value.strip()
+    return None
+
+
 @click.group()
 @click.version_option()
 @click.pass_context
@@ -72,12 +84,12 @@ def setup(ctx):
     ))
 
     config = ctx.obj["config"]
-    new_config = {
-        "device": dict(config.get("device", {})),
-        "api": dict(config.get("api", {})),
-        "output": dict(config.get("output", {})),
-        "defaults": dict(config.get("defaults", {})),
-    }
+    # Carry over every existing section so re-running setup never wipes
+    # settings the wizard doesn't manage (e.g. [analysis]).
+    new_config = {section: dict(values) for section, values in config.items()
+                  if isinstance(values, dict)}
+    for section in ("device", "api", "output", "defaults"):
+        new_config.setdefault(section, {})
 
     # Step 1: Device address
     console.print("\n[bold cyan]Step 1: Device Address[/bold cyan]")
@@ -109,10 +121,10 @@ def setup(ctx):
 
     console.print("\n  [bold]Session Key[/bold] (16 characters, authenticates the BLE connection)")
     console.print("  [dim]Capture it from the vendor app's APP&SK& write — see PROTOCOL.md.[/dim]")
-    existing_sk = new_config["device"].get("session_key", "")
-    masked_sk = f"...{existing_sk[-4:]}" if len(existing_sk) > 4 else ""
-    sk = click.prompt("  Session key", default=masked_sk or "", show_default=bool(masked_sk))
-    if sk and not sk.startswith("..."):
+    sk = _prompt_secret("  Session key", new_config["device"].get("session_key", ""))
+    if sk:
+        if len(sk) != 16:
+            console.print("  [yellow]Warning: session keys are 16 characters — double-check the value.[/yellow]")
         new_config["device"]["session_key"] = sk
 
     # Step 2: API keys
@@ -122,19 +134,15 @@ def setup(ctx):
     console.print("  [dim]Get one at: https://console.anthropic.com/settings/keys[/dim]")
     console.print("  [dim]Cost: ~$0.003 per recording (summary + entities + mind map)[/dim]")
     console.print("  [dim]Transcription works without this key (runs locally).[/dim]")
-    existing_key = new_config["api"].get("anthropic_key", "")
-    masked = f"...{existing_key[-4:]}" if len(existing_key) > 4 else ""
-    anthropic_key = click.prompt("  Anthropic API key", default=masked or "", show_default=bool(masked))
-    if anthropic_key and not anthropic_key.startswith("..."):
+    anthropic_key = _prompt_secret("  Anthropic API key", new_config["api"].get("anthropic_key", ""))
+    if anthropic_key:
         new_config["api"]["anthropic_key"] = anthropic_key
 
     console.print("\n  [bold]HuggingFace Token[/bold] (optional, for speaker identification)")
     console.print("  [dim]Get one at: https://huggingface.co/settings/tokens[/dim]")
     console.print("  [dim]Free tier works. Enables speaker diarization.[/dim]")
-    existing_hf = new_config["api"].get("hf_token", "")
-    masked_hf = f"...{existing_hf[-4:]}" if len(existing_hf) > 4 else ""
-    hf_token = click.prompt("  HuggingFace token", default=masked_hf or "", show_default=bool(masked_hf))
-    if hf_token and not hf_token.startswith("..."):
+    hf_token = _prompt_secret("  HuggingFace token", new_config["api"].get("hf_token", ""))
+    if hf_token:
         new_config["api"]["hf_token"] = hf_token
 
     # Step 3: Output directory
@@ -170,7 +178,7 @@ def setup(ctx):
         if click.confirm("\n  Test connection to device?", default=True):
             try:
                 async def _test():
-                    sk = resolve_session_key(new_config)
+                    sk = new_config["device"]["session_key"]
                     async with PocketCommander(new_config["device"]["address"]) as cmd:
                         ok = await cmd.authenticate(sk)
                         if ok:
@@ -182,6 +190,16 @@ def setup(ctx):
             except Exception as e:
                 console.print(f"  [yellow]Connection failed: {e}[/yellow]")
                 console.print("  [dim]Make sure the device is awake (press button).[/dim]")
+
+    if not new_config["device"].get("session_key"):
+        console.print(Panel(
+            "[bold yellow]No session key configured.[/bold yellow]\n\n"
+            "Device commands (status, list, download, sync, web) won't work\n"
+            "until you set one. Capture it from the vendor app's APP&SK& write\n"
+            "(see PROTOCOL.md), then run:\n"
+            "  pocket-libre config --set device.session_key=YOUR-KEY",
+            border_style="yellow",
+        ))
 
     console.print(Panel(
         "[bold green]Setup complete![/bold green]\n\n"
@@ -229,7 +247,7 @@ def show_config(ctx, show_path: bool, set_value: str | None):
         console.print(f"\n[bold cyan][{section}][/bold cyan]")
         for key, val in values.items():
             display = val
-            if key in ("anthropic_key", "hf_token") and val and len(str(val)) > 8:
+            if key in ("anthropic_key", "hf_token", "session_key") and val and len(str(val)) > 8:
                 display = f"...{str(val)[-4:]}"
             console.print(f"  {key} = {display}")
 
@@ -502,7 +520,7 @@ def download_all(ctx, address: str | None, session_key: str | None,
             console.print("[dim]Authenticating...[/dim]")
             if not await cmd.authenticate(session_key):
                 console.print("[red]Auth failed.[/red]")
-                return
+                return []
 
             all_recs = await cmd.list_all_recordings()
             if since:
@@ -510,7 +528,7 @@ def download_all(ctx, address: str | None, session_key: str | None,
 
             if not all_recs:
                 console.print("[yellow]No recordings found.[/yellow]")
-                return
+                return []
 
             console.print(f"[bold]{len(all_recs)} recording(s) to download[/bold]\n")
 
@@ -546,8 +564,9 @@ def download_all(ctx, address: str | None, session_key: str | None,
                     console.print(f"    [red]No data received[/red]")
 
             console.print(f"\n[bold green]Downloaded {len(downloaded_paths)} recording(s) to {out_root}[/bold green]")
+            return downloaded_paths
 
-    asyncio.run(_run())
+    downloaded_paths = asyncio.run(_run())
 
     if do_process and downloaded_paths:
         console.print("\n[bold cyan]Processing recordings...[/bold cyan]\n")
@@ -575,13 +594,14 @@ def download_all(ctx, address: str | None, session_key: str | None,
               help="Summary style.")
 @click.option("--anthropic-key", default=None, help="Anthropic API key (or set ANTHROPIC_API_KEY).")
 @click.option("--hf-token", default=None, help="HuggingFace token for speaker diarization.")
+@click.option("--key", "session_key", default=None, help="Session key.")
 @click.option("--skip-process", is_flag=True, help="Only download, skip transcription and summary.")
 @click.option("--prompt", default=None, help="Custom summary prompt (use {transcript} placeholder).")
 @click.pass_context
 def sync(ctx, address: str | None, output_dir: str | None, since: str | None,
          whisper_model: str | None, style: str | None,
          anthropic_key: str | None, hf_token: str | None,
-         skip_process: bool, prompt: str | None):
+         session_key: str | None, skip_process: bool, prompt: str | None):
     """Sync all new recordings: download, transcribe, summarize.
 
     \b
@@ -598,7 +618,7 @@ def sync(ctx, address: str | None, output_dir: str | None, since: str | None,
     style = style or get(config, "defaults", "summary_style", default="meeting")
     anthropic_key = resolve_anthropic_key(config, anthropic_key)
     hf_token = resolve_hf_token(config, hf_token)
-    session_key = _require_session_key(None, config)
+    session_key = _require_session_key(session_key, config)
 
     if not anthropic_key and not skip_process:
         console.print(Panel(

--- a/src/pocket_libre/cli.py
+++ b/src/pocket_libre/cli.py
@@ -36,6 +36,17 @@ def _require_address(address: str | None, config: dict) -> str:
     return addr
 
 
+def _require_session_key(session_key: str | None, config: dict) -> str:
+    """Resolve session key or exit with helpful error."""
+    sk = resolve_session_key(config, session_key)
+    if not sk:
+        raise click.UsageError(
+            "No session key. Run 'pocket-libre setup' or pass --key.\n"
+            "Capture yours from the vendor app's APP&SK& write (see PROTOCOL.md)."
+        )
+    return sk
+
+
 @click.group()
 @click.version_option()
 @click.pass_context
@@ -96,6 +107,14 @@ def setup(ctx):
     if addr:
         new_config["device"]["address"] = addr
 
+    console.print("\n  [bold]Session Key[/bold] (16 characters, authenticates the BLE connection)")
+    console.print("  [dim]Capture it from the vendor app's APP&SK& write — see PROTOCOL.md.[/dim]")
+    existing_sk = new_config["device"].get("session_key", "")
+    masked_sk = f"...{existing_sk[-4:]}" if len(existing_sk) > 4 else ""
+    sk = click.prompt("  Session key", default=masked_sk or "", show_default=bool(masked_sk))
+    if sk and not sk.startswith("..."):
+        new_config["device"]["session_key"] = sk
+
     # Step 2: API keys
     console.print("\n[bold cyan]Step 2: API Keys[/bold cyan]")
 
@@ -147,7 +166,7 @@ def setup(ctx):
     console.print(f"\n[green]Config saved to {CONFIG_FILE}[/green]")
 
     # Test connection
-    if new_config["device"].get("address"):
+    if new_config["device"].get("address") and new_config["device"].get("session_key"):
         if click.confirm("\n  Test connection to device?", default=True):
             try:
                 async def _test():
@@ -331,7 +350,7 @@ def status(ctx, address: str | None, session_key: str | None):
     """Connect to Pocket and show device status (battery, firmware, storage)."""
     config = ctx.obj["config"]
     address = _require_address(address, config)
-    session_key = resolve_session_key(config, session_key)
+    session_key = _require_session_key(session_key, config)
 
     async def _run():
         async with PocketCommander(address) as cmd:
@@ -371,7 +390,7 @@ def list_recordings(ctx, address: str | None, session_key: str | None, date: str
     """List recordings stored on the Pocket device."""
     config = ctx.obj["config"]
     address = _require_address(address, config)
-    session_key = resolve_session_key(config, session_key)
+    session_key = _require_session_key(session_key, config)
 
     from rich.table import Table
 
@@ -421,7 +440,7 @@ def download(ctx, address: str | None, session_key: str | None,
     """Download a specific recording over BLE."""
     config = ctx.obj["config"]
     address = _require_address(address, config)
-    session_key = resolve_session_key(config, session_key)
+    session_key = _require_session_key(session_key, config)
     from pocket_libre.protocol import MP3_SYNC_WORD
 
     async def _run():
@@ -474,7 +493,7 @@ def download_all(ctx, address: str | None, session_key: str | None,
     """
     config = ctx.obj["config"]
     address = _require_address(address, config)
-    session_key = resolve_session_key(config, session_key)
+    session_key = _require_session_key(session_key, config)
     out_root = Path(get_output_dir(config, output_dir))
     from pocket_libre.protocol import MP3_SYNC_WORD
 
@@ -579,7 +598,7 @@ def sync(ctx, address: str | None, output_dir: str | None, since: str | None,
     style = style or get(config, "defaults", "summary_style", default="meeting")
     anthropic_key = resolve_anthropic_key(config, anthropic_key)
     hf_token = resolve_hf_token(config, hf_token)
-    session_key = resolve_session_key(config)
+    session_key = _require_session_key(None, config)
 
     if not anthropic_key and not skip_process:
         console.print(Panel(

--- a/src/pocket_libre/commands.py
+++ b/src/pocket_libre/commands.py
@@ -142,6 +142,8 @@ class PocketCommander:
     # ── Device Info ──────────────────────────────
 
     async def authenticate(self, session_key: str) -> bool:
+        if not session_key:
+            raise ValueError("No session key configured.")
         responses = await self._send(f"SK&{session_key}")
         return any("MCU&SK&OK" in r for r in responses)
 

--- a/src/pocket_libre/commands.py
+++ b/src/pocket_libre/commands.py
@@ -276,7 +276,7 @@ class PocketCommander:
         """Get WiFi AP credentials. Returns (ssid, password) or None."""
         responses = await self._send("WIFI")
         for r in responses:
-            # MCU&WIFI&PKT01_GREY_XXXXXXXX&xJiEbRKn
+            # MCU&WIFI&<ssid>&<password>
             if r.startswith(f"{RSP_PREFIX}WIFI&"):
                 parts = r.split("&")
                 if len(parts) >= 4:

--- a/src/pocket_libre/config.py
+++ b/src/pocket_libre/config.py
@@ -100,8 +100,8 @@ def resolve_address(config: dict, cli_value: str | None = None) -> str | None:
     return get(config, "device", "address", cli_value=cli_value)
 
 
-def resolve_session_key(config: dict, cli_value: str | None = None) -> str | None:
-    """Resolve session key from config chain."""
+def resolve_session_key(config: dict, cli_value: str | None = None) -> str:
+    """Resolve session key from config chain. Returns "" when unset."""
     return get(config, "device", "session_key", cli_value=cli_value)
 
 

--- a/src/pocket_libre/config.py
+++ b/src/pocket_libre/config.py
@@ -15,7 +15,7 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 DEFAULTS = {
     "device": {
         "address": "",
-        "session_key": "xJiEbRKnKrhCqvoZ",
+        "session_key": "",
     },
     "api": {
         "anthropic_key": "",
@@ -100,10 +100,9 @@ def resolve_address(config: dict, cli_value: str | None = None) -> str | None:
     return get(config, "device", "address", cli_value=cli_value)
 
 
-def resolve_session_key(config: dict, cli_value: str | None = None) -> str:
-    """Resolve session key with hardcoded fallback."""
-    return get(config, "device", "session_key", cli_value=cli_value,
-               default="xJiEbRKnKrhCqvoZ")
+def resolve_session_key(config: dict, cli_value: str | None = None) -> str | None:
+    """Resolve session key from config chain."""
+    return get(config, "device", "session_key", cli_value=cli_value)
 
 
 def resolve_anthropic_key(config: dict, cli_value: str | None = None) -> str | None:

--- a/src/pocket_libre/web/app.py
+++ b/src/pocket_libre/web/app.py
@@ -59,7 +59,7 @@ async def get_config():
             continue
         safe[section] = {}
         for k, v in values.items():
-            if k in ("anthropic_key", "hf_token") and v and len(str(v)) > 8:
+            if k in ("anthropic_key", "hf_token", "session_key") and v and len(str(v)) > 8:
                 safe[section][k] = f"...{str(v)[-4:]}"
                 safe[section][f"_{k}_set"] = True
             else:
@@ -82,6 +82,17 @@ async def update_config(update: ConfigUpdate):
                 config[section][k] = v
     save_config(config)
     return {"status": "ok"}
+
+
+def _require_device(config: dict) -> tuple[str, str]:
+    """Resolve device address and session key, or raise 400 pointing to Settings."""
+    address = resolve_address(config)
+    if not address:
+        raise HTTPException(400, "No device address configured. Go to Settings.")
+    sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
+    return address, sk
 
 
 # ── Device Scan & Status ────────────────────────
@@ -115,12 +126,7 @@ async def device_busy():
 @app.get("/api/device/status")
 async def device_status():
     config = load_config()
-    address = resolve_address(config)
-    if not address:
-        raise HTTPException(400, "No device address configured. Go to Settings.")
-    sk = resolve_session_key(config)
-    if not sk:
-        raise HTTPException(400, "No session key configured. Go to Settings.")
+    address, sk = _require_device(config)
 
     if ble_lock.locked():
         raise HTTPException(409, "Device is busy with another operation.")
@@ -156,12 +162,7 @@ async def device_status():
 @app.get("/api/device/recordings")
 async def device_recordings():
     config = load_config()
-    address = resolve_address(config)
-    if not address:
-        raise HTTPException(400, "No device address configured.")
-    sk = resolve_session_key(config)
-    if not sk:
-        raise HTTPException(400, "No session key configured. Go to Settings.")
+    address, sk = _require_device(config)
 
     if ble_lock.locked():
         raise HTTPException(409, "Device is busy.")
@@ -195,12 +196,7 @@ async def device_recordings():
 async def download_recording(date: str, timestamp: str):
     """Download a recording over BLE with SSE progress updates."""
     config = load_config()
-    address = resolve_address(config)
-    if not address:
-        raise HTTPException(400, "No device address configured.")
-    sk = resolve_session_key(config)
-    if not sk:
-        raise HTTPException(400, "No session key configured. Go to Settings.")
+    address, sk = _require_device(config)
     out_root = Path(get_output_dir(config))
 
     if ble_lock.locked():
@@ -268,25 +264,26 @@ async def download_recording(date: str, timestamp: str):
 async def process_recording(date: str, timestamp: str):
     """Download, transcribe, and summarize with SSE progress."""
     config = load_config()
-    address = resolve_address(config)
-    if not address:
-        raise HTTPException(400, "No device address configured.")
-    sk = resolve_session_key(config)
-    if not sk:
-        raise HTTPException(400, "No session key configured. Go to Settings.")
     out_root = Path(get_output_dir(config))
+    audio_path = out_root / date / f"{timestamp}.mp3"
+    # Device access is only needed when the audio isn't on disk yet;
+    # reprocessing a downloaded file must work without a session key.
+    needs_download = not audio_path.exists()
+    if needs_download:
+        address, sk = _require_device(config)
+    else:
+        address = sk = None
     whisper_model = get(config, "defaults", "whisper_model", default="base.en")
     summary_style = get(config, "defaults", "summary_style", default="meeting")
     anthropic_key = resolve_anthropic_key(config)
     hf_token = resolve_hf_token(config)
 
     async def event_stream():
-        rec_dir = out_root / date
+        rec_dir = audio_path.parent
         rec_dir.mkdir(parents=True, exist_ok=True)
-        audio_path = rec_dir / f"{timestamp}.mp3"
 
         # Download if not already on disk
-        if not audio_path.exists():
+        if needs_download:
             if ble_lock.locked():
                 yield _sse({"step": "error", "message": "Device is busy."})
                 return
@@ -405,12 +402,7 @@ async def process_recording(date: str, timestamp: str):
 async def sync_all():
     """Download all new recordings, transcribe, and summarize. SSE progress."""
     config = load_config()
-    address = resolve_address(config)
-    if not address:
-        raise HTTPException(400, "No device address configured.")
-    sk = resolve_session_key(config)
-    if not sk:
-        raise HTTPException(400, "No session key configured. Go to Settings.")
+    address, sk = _require_device(config)
     out_root = Path(get_output_dir(config))
     whisper_model = get(config, "defaults", "whisper_model", default="base.en")
     summary_style = get(config, "defaults", "summary_style", default="meeting")

--- a/src/pocket_libre/web/app.py
+++ b/src/pocket_libre/web/app.py
@@ -119,6 +119,8 @@ async def device_status():
     if not address:
         raise HTTPException(400, "No device address configured. Go to Settings.")
     sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
 
     if ble_lock.locked():
         raise HTTPException(409, "Device is busy with another operation.")
@@ -158,6 +160,8 @@ async def device_recordings():
     if not address:
         raise HTTPException(400, "No device address configured.")
     sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
 
     if ble_lock.locked():
         raise HTTPException(409, "Device is busy.")
@@ -195,6 +199,8 @@ async def download_recording(date: str, timestamp: str):
     if not address:
         raise HTTPException(400, "No device address configured.")
     sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
     out_root = Path(get_output_dir(config))
 
     if ble_lock.locked():
@@ -266,6 +272,8 @@ async def process_recording(date: str, timestamp: str):
     if not address:
         raise HTTPException(400, "No device address configured.")
     sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
     out_root = Path(get_output_dir(config))
     whisper_model = get(config, "defaults", "whisper_model", default="base.en")
     summary_style = get(config, "defaults", "summary_style", default="meeting")
@@ -401,6 +409,8 @@ async def sync_all():
     if not address:
         raise HTTPException(400, "No device address configured.")
     sk = resolve_session_key(config)
+    if not sk:
+        raise HTTPException(400, "No session key configured. Go to Settings.")
     out_root = Path(get_output_dir(config))
     whisper_model = get(config, "defaults", "whisper_model", default="base.en")
     summary_style = get(config, "defaults", "summary_style", default="meeting")

--- a/src/pocket_libre/web/static/index.html
+++ b/src/pocket_libre/web/static/index.html
@@ -220,8 +220,8 @@ tr:hover td { background: var(--bg3); }
       </div>
       <div class="form-group">
         <label>Session Key</label>
-        <input type="text" id="cfgSessionKey" placeholder="xJiEbRKnKrhCqvoZ">
-        <div class="hint">Authentication key. Default usually works.</div>
+        <input type="text" id="cfgSessionKey" placeholder="16-character session key">
+        <div class="hint">Authenticates the BLE connection. Capture it from the vendor app's APP&amp;SK&amp; write — see PROTOCOL.md.</div>
       </div>
     </div>
     <div class="card">

--- a/src/pocket_libre/web/static/index.html
+++ b/src/pocket_libre/web/static/index.html
@@ -788,8 +788,12 @@ async function loadSettings() {
     const cfg = await r.json();
 
     document.getElementById('cfgAddress').value = cfg.device?.address || '';
-    document.getElementById('cfgSessionKey').value = cfg.device?.session_key || '';
     document.getElementById('cfgOutputDir').value = cfg.output?.directory || '~/Pocket Libre';
+
+    // Session key - show masked if set
+    const skField = document.getElementById('cfgSessionKey');
+    if (cfg.device?._session_key_set) skField.placeholder = cfg.device.session_key + ' (saved)';
+    else skField.value = cfg.device?.session_key || '';
 
     // API keys - show masked if set
     const akField = document.getElementById('cfgAnthropicKey');
@@ -809,7 +813,6 @@ async function saveSettings() {
   const config = {
     device: {
       address: document.getElementById('cfgAddress').value,
-      session_key: document.getElementById('cfgSessionKey').value,
     },
     api: {},
     output: {
@@ -821,6 +824,8 @@ async function saveSettings() {
     },
   };
 
+  const sk = document.getElementById('cfgSessionKey').value;
+  if (sk) config.device.session_key = sk;
   const ak = document.getElementById('cfgAnthropicKey').value;
   if (ak) config.api.anthropic_key = ak;
   const hf = document.getElementById('cfgHfToken').value;


### PR DESCRIPTION
## Summary

The device session key (whose first 8 characters double as the device's WiFi AP password) was exposed verbatim in seven places across docs and code. This PR scrubs it everywhere and makes the session key a proper per-user config value:

- **README.md** — config example now uses a `YOUR-SESSION-KEY` placeholder; setup docs mention where the key comes from
- **PROTOCOL.md** — auth and WiFi-credential examples use placeholders instead of the real key/password
- **config.py** — removed the hardcoded session-key fallback
- **cli.py** — commands fail with a clear usage error when no key is configured; setup wizard now prompts for the session key (masked when already set)
- **web/app.py** — device endpoints return HTTP 400 with a pointer to Settings when no key is configured
- **web/static/index.html** — Settings placeholder/hint no longer show the real key
- **commands.py** — comment no longer embeds the real WiFi AP password

## Behavior change

Previously the tool silently authenticated with the hardcoded key. Now users must supply their own key via `pocket-libre setup`, `--key`, or the web Settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcFwbiBD9TJoUFKyy7f7Sg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcFwbiBD9TJoUFKyy7f7Sg)_